### PR TITLE
OldCRT.glsl fix only top left quadrant drawn.

### DIFF
--- a/Artistic/OldCRT.glsl
+++ b/Artistic/OldCRT.glsl
@@ -63,7 +63,7 @@ vec4 darken_color(vec4 color, vec2 coords)
     }
 
     // Get how far the coords are from the center
-    vec2 distances_from_center = window_center - coords;
+    vec2 distances_from_center = abs(window_center - coords);
 
     // Darken pixels close to the edges of the screen in a polynomial fashion
     float brightness = 1;


### PR DESCRIPTION
distances_from_center was becoming negative and turning all colors black aside the top left quadrant.

![noabs](https://user-images.githubusercontent.com/5022760/236542353-4d9fc9d2-e5ac-466d-8316-92c6651b790f.png)
![abs](https://user-images.githubusercontent.com/5022760/236542367-34a93073-da82-45b5-9646-4a5be66b2dcb.png)
