### PR TITLE
Add rounded-corner border shaders for i3wm (focused & unfocused windows)

### DIFF
--- a/Artistic/focused_border.glsl
+++ b/Artistic/focused_border.glsl
@@ -1,0 +1,50 @@
+#version 330
+
+in vec2 texcoord;
+uniform sampler2D tex;
+uniform float opacity;
+uniform float corner_radius;
+
+vec4 default_post_processing(vec4 c);
+
+// Function to check if a point is inside a rounded rectangle
+bool inside_rounded_rect(vec2 pos, vec2 size, float radius) {
+    vec2 center = size * 0.5;
+    vec2 d = abs(pos - center) - (center - radius);
+    return length(max(d, 0.0)) <= radius;
+}
+
+vec4 window_shader() {
+    vec4 c = texelFetch(tex, ivec2(texcoord), 0);
+    c = default_post_processing(c);
+    
+    ivec2 window_size = textureSize(tex, 0);
+    float border_width = 3.0;
+    vec2 pos = vec2(texcoord.x, texcoord.y);
+    vec2 size = vec2(window_size.x, window_size.y);
+    float radius = corner_radius;
+    
+    // Check if we're inside the outer rounded rectangle (window boundary)
+    bool inside_outer = inside_rounded_rect(pos, size, radius);
+    
+    // If we're outside the window entirely, make transparent
+    if (!inside_outer) {
+        return vec4(0.0, 0.0, 0.0, 0.0);
+    }
+    
+    // Check if we're inside the inner rounded rectangle (content area)
+    // The inner rectangle is smaller by border_width on all sides
+    vec2 inner_size = size - vec2(border_width * 2.0);
+    vec2 inner_pos = pos - vec2(border_width);
+    float inner_radius = max(0.0, radius - border_width * 0.5);
+    
+    bool inside_inner = inside_rounded_rect(inner_pos, inner_size, inner_radius);
+    
+    // If we're between outer and inner rounded rectangles, we're in the border
+    if (!inside_inner) {
+        return vec4(1.0, 0.3, 0.9, 1.0); // Neon pink-purple
+    }
+    
+    // Inside the content area
+    return c;
+}

--- a/Artistic/unfocused_border.glsl
+++ b/Artistic/unfocused_border.glsl
@@ -1,0 +1,49 @@
+#version 330
+
+in vec2 texcoord;
+uniform sampler2D tex;
+uniform float opacity;
+uniform float corner_radius;
+
+vec4 default_post_processing(vec4 c);
+
+// Function to check if a point is inside a rounded rectangle
+bool inside_rounded_rect(vec2 pos, vec2 size, float radius) {
+    vec2 center = size * 0.5;
+    vec2 d = abs(pos - center) - (center - radius);
+    return length(max(d, 0.0)) <= radius;
+}
+
+vec4 window_shader() {
+    vec4 c = texelFetch(tex, ivec2(texcoord), 0);
+    c = default_post_processing(c);
+    
+    ivec2 window_size = textureSize(tex, 0);
+    float border_width = 3.0;
+    vec2 pos = vec2(texcoord.x, texcoord.y);
+    vec2 size = vec2(window_size.x, window_size.y);
+    float radius = corner_radius;
+    
+    // Check if we're inside the outer rounded rectangle (window boundary)
+    bool inside_outer = inside_rounded_rect(pos, size, radius);
+    
+    // If we're outside the window entirely, make transparent
+    if (!inside_outer) {
+        return vec4(0.0, 0.0, 0.0, 0.0);
+    }
+    
+    // Check if we're inside the inner rounded rectangle (content area)
+    // The inner rectangle is smaller by border_width on all sides
+    vec2 inner_size = size - vec2(border_width * 2.0);
+    vec2 inner_pos = pos - vec2(border_width);
+    float inner_radius = max(0.0, radius - border_width * 0.5);
+    
+    bool inside_inner = inside_rounded_rect(inner_pos, inner_size, inner_radius);
+    
+    // If we're between outer and inner rounded rectangles, we're in the border
+    if (!inside_inner) {
+        return vec4(0.5, 0.5, 0.5, 1.0); // Darker grey border
+    }
+    
+    return c;
+}


### PR DESCRIPTION
This PR adds two new GLSL shaders under the Artistic/ folder:

- focused_border.glsl
- unfocused_border.glsl

How it looks: 
<img width="1919" height="1044" alt="image" src="https://github.com/user-attachments/assets/b9ef58c5-6559-4bdc-9db3-e63b05d68ab3" />

These shaders implement true rounded window corners with shader-drawn borders, designed specifically to work well with i3wm + picom setups.

I originally built these for my own setup: the hacks I was using earlier for rounded corners ooked pretty meh and broke easily across apps. This shader-based approach ended up being much cleaner and more predictable, so I I'm sharing it here in case it helps others running tiling WMs.

Instead of relying on compositor blur tricks or client-side decorations, the shaders:

- Clip the window to a rounded rectangle 
- Render a configurable border between inner and outer rounded regions
- Preserve the window’s content rendering via default_post_processing

Why this is useful

i3wm users don't have rounded corners and this also adds it for distinct focused vs unfocused borders without any patches or window manager hacks.

This PR:

- Makes rounded borders easy to enable via picom rules
- Works cleanly with match = "focused" / !focused
- Avoids affecting docks, menus, fullscreen windows, etc.

How it works (high level)
The shader:

- Defines an inside_rounded_rect() helper to determine pixel inclusion
- Computes:
- An outer rounded rectangle (window bounds)
- An inner rounded rectangle (content area)
- Pixels between the two rectangles are rendered as the border
- Pixels outside the outer rectangle are fully transparent


Configuration example

Example picom rule for focused windows:

```
{
  match = "focused && !fullscreen &&
           class_g != 'Polybar' &&
           class_g != 'i3lock' &&
           class_g != 'rofi' &&
           window_type != 'dock' &&
           window_type != 'desktop'";

  shader = "/path/to/picom-shaders/Artistic/focused_border.glsl";
  opacity = 0.90;
  shader-uniforms = "border_width=5.0";
}

```

The shader also supports corner_radius (via picom’s existing uniform) and easy color tweaks inside the shader for focused/unfocused states

Notes:

- Tested with i3wm + picom (GLX backend)
- Designed for tiling window managers (not CSD environments)
- Borders are fully shader-controlled (no WM border dependency)